### PR TITLE
Expand mender boot partition size

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ IMAGE_INSTALL_append = " kernel-image kernel-devicetree"
 
 MENDER_IMAGE_BOOTLOADER_FILE = "u-boot-${MACHINE}.bin"
 
+MENDER_BOOT_PART_SIZE_MB = "32"
+
 MENDER_FEATURES_ENABLE_append = " mender-uboot mender-image-sd"
 MENDER_FEATURES_DISABLE_append = " mender-grub mender-image-uefi"
 ```


### PR DESCRIPTION
This commit fixes an error related to the mender boot parition size.

When issuing the command `bitbake core-image--minimal` inside the `crops/poky:ubuntu-20.04` container, I obtained the following output on multiple computers.
~~~
Initialising tasks: 100% |#####################################################################################################################################################################################################| Time: 0:00:03
Sstate summary: Wanted 2 Found 0 Missed 2 Current 1258 (0% match, 99% complete)
NOTE: Executing Tasks
ERROR: core-image-minimal-1.0-r0 do_image_sdimg: Execution of '/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/temp/run.do_image_sdimg.101' failed with exit code 1
ERROR: Logfile of failure stored in: /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/temp/log.do_image_sdimg.101
Log data follows:
| DEBUG: Executing python function prepare_excluded_directories
| DEBUG: 'IMAGE_ROOTFS_EXCLUDE_PATH' is set but 'respect_exclude_path' variable flag is 0 for this image type, so ignoring it
| DEBUG: Python function prepare_excluded_directories finished
| DEBUG: Executing python function set_image_size
| DEBUG: 98228.000000 = 75560 * 1.300000
| DEBUG: 434176.000000 = max(98228.000000, 430080)[430080.000000] + 4096
| DEBUG: 434176.000000 = int(434176.000000)
| DEBUG: 434176 = aligned(434176)
| DEBUG: returning 434176
| DEBUG: Python function set_image_size finished
| DEBUG: Executing python function extend_recipe_sysroot
| NOTE: Direct dependencies are ['virtual:native:/espressobin/sources/poky/meta/recipes-core/update-rc.d/update-rc.d_0.8.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-core/glibc/glibc_2.31.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/e2fsprogs/e2fsprogs_1.45.7.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/createrepo-c/createrepo-c_0.15.7.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-core/glibc/ldconfig-native_2.12.1.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/patch/patch_2.7.6.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-kernel/kern-tools/kern-tools-native_git.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-extended/bc/bc_1.07.1.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/meta-mender/meta-mender-core/recipes-devtools/dosfstools/dosfstools_4.2.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/pseudo/pseudo_git.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-devtools/gcc/gcc-cross_9.3.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-support/bmap-tools/bmap-tools_3.5.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-core/glibc/cross-localedef-native_2.31.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-devtools/qemu/qemuwrapper-cross_1.0.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/opkg/opkg_0.4.2.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/makedevs/makedevs_1.0.1.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-kernel/kmod/depmodwrapper-cross_1.0.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-core/meta/wic-tools.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/prelink/prelink_git.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-core/coreutils/coreutils_8.31.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/btrfs-tools/btrfs-tools_5.4.1.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/opkg-utils/opkg-utils_0.4.2.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/squashfs-tools/squashfs-tools_git.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/dnf/dnf_4.2.2.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-kernel/dtc/dtc_1.6.0.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-devtools/mklibs/mklibs-native_0.1.44.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/swig/swig_3.0.12.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-extended/parted/parted_3.3.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/rpm/rpm_4.14.2.1.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-extended/pbzip2/pbzip2_1.1.13.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-extended/pigz/pigz_2.4.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/syslinux/syslinux_6.04-pre2.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-devtools/quilt/quilt-native_0.66.bb:do_populate_sysroot', 'virtual:multilib:lib32:/espressobin/sources/poky/meta/recipes-devtools/qemu/qemuwrapper-cross_1.0.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/fdisk/gptfdisk_1.0.4.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-devtools/gcc/gcc-runtime_9.3.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/python/python3_3.8.12.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-connectivity/openssl/openssl_1.1.1l.bb:do_populate_sysroot', 'virtual:native:/espressobin/sources/poky/meta/recipes-devtools/mtools/mtools_4.0.23.bb:do_populate_sysroot', '/espressobin/sources/poky/meta/recipes-devtools/cdrtools/cdrtools-native_3.01.bb:do_populate_sysroot']
| NOTE: Installed into sysroot: []
| NOTE: Skipping as already exists in sysroot: ['update-rc.d-native', 'glibc', 'e2fsprogs-native', 'createrepo-c-native', 'ldconfig-native', 'patch-native', 'kern-tools-native', 'bc-native', 'dosfstools-native', 'pseudo-native', 'gcc-cross-aarch64', 'bmap-tools-native', 'cross-localedef-native', 'qemuwrapper-cross', 'opkg-native', 'makedevs-native', 'depmodwrapper-cross', 'wic-tools', 'prelink-native', 'coreutils-native', 'btrfs-tools-native', 'opkg-utils-native', 'squashfs-tools-native', 'dnf-native', 'dtc-native', 'mklibs-native', 'swig-native', 'parted-native', 'rpm-native', 'pbzip2-native', 'pigz-native', 'syslinux-native', 'quilt-native', 'lib32-qemuwrapper-cross', 'gptfdisk-native', 'gcc-runtime', 'python3-native', 'openssl-native', 'mtools-native', 'cdrtools-native', 'shadow-native', 'systemd-systemctl-native', 'texinfo-dummy-native', 'automake-native', 'autoconf-native', 'util-linux-native', 'attr-native', 'pkgconfig-native', 'libtool-native', 'gnu-config-native', 'gettext-minimal-native', 'flex-native', 'readline-native', 'python3-setuptools-native', 'python3-six-native', 'kmod-native', 'elfutils-native', 'binutils-native', 'debianutils-native', 'xz-native', 'lzo-native', 'acl-native', 'libdnf-native', 'python3-iniparse-native', 'librepo-native', 'cmake-native', 'libcomps-native', 'ninja-native', 'libpcre-native', 'ncurses-native', 'qemu-native', 'zlib-native', 'nasm-native', 'popt-native', 'shared-mime-info-native', 'linux-libc-headers', 'libxml2-native', 'file-native', 'curl-native', 'glib-2.0-native', 'sqlite3-native', 'expat-native', 'gmp-native', 'mpfr-native', 'libmpc-native', 'binutils-cross-aarch64', 'libarchive-native', 'libsolv-native', 'perl-native', 'lz4-native', 'bzip2-native', 'dbus-native', 'db-native', 'libgcc', 'libffi-native', 'libnsl2-native', 'libtirpc-native', 'gdbm-native', 'm4-native', 'libpcre2-native', 'libcap-ng-native', 'unzip-native', 'gtk-doc-native', 'gobject-introspection-native', 'json-c-native', 'libcheck-native', 'libmodulemd-v1-native', 'gpgme-native', 're2c-native', 'groff-native', 'itstool-native', 'gettext-native', 'meson-native', 'libyaml-native', 'libgpg-error-native', 'libassuan-native']
| DEBUG: Python function extend_recipe_sysroot finished
| DEBUG: Executing shell function do_image_sdimg
| + mkdir -p /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0
| + true
| + install -m 0644 /espressobin/build/tmp/deploy/images/espressobin-v7/uboot.env /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/
| ++ basename /dev/mmcblk0
| + ondisk_dev=mmcblk0
| + wks=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/mender-sdimg.wks
| + rm -f /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/mender-sdimg.wks
| + '[' -n u-boot-espressobin-v7.bin ']'
| + install -m 0644 /espressobin/build/tmp/deploy/images/espressobin-v7/u-boot-espressobin-v7.bin /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/
| ++ expr 2 % 2
| + '[' 0 -ne 0 ']'
| + bootloader_sector=2
| + bootloader_file=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/u-boot-espressobin-v7.bin
| +++ expr 2 '*' 512
| ++ expr 1024 / 1024
| + bootloader_align_kb=1
| ++ stat -c %s /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/u-boot-espressobin-v7.bin
| + bootloader_size=608562
| ++ expr 1 '*' 1024 + 608562
| + bootloader_end=609586
| + '[' 609586 -gt 8388608 ']'
| + cat
| + true
| + '[' -n 8388608 ']'
| ++ expr 8388608 / 1024
| + boot_env_align_kb=8192
| + cat
| ++ expr 8388608 % 1024
| ++ true
| + '[' 0 -ne 0 ']'
| ++ expr 8388608 / 1024
| + alignment_kb=8192
| + '[' msdos = gpt ']'
| + part_type_params=
| ++ echo 'Image;Image armada-3720-espressobin-v7-emmc.dtb;fdt.dtb'
| ++ sed -r 's/(^\s*)|(\s*$)//g'
| + IMAGE_BOOT_FILES_STRIPPED='Image;Image armada-3720-espressobin-v7-emmc.dtb;fdt.dtb'
| + '[' 16 -ne 0 ']'
| + mender_merge_bootfs_and_image_boot_files
| + W=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg
| + rm -rf /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg
| + cp -al /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/rootfs//uboot /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg
| + image_boot_files='Image;Image armada-3720-espressobin-v7-emmc.dtb;fdt.dtb'
| + for entry in $image_boot_files
| + echo 'Image;Image'
| + grep -q ';'
| ++ echo 'Image;Image'
| ++ sed -e 's/[^;]*;//'
| + dest=Image
| ++ echo 'Image;Image'
| ++ sed -e 's/;.*//'
| + entry=Image
| + echo Image
| + grep -q '/$'
| + dest_is_dir=0
| ++ dirname /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg/Image
| + mkdir -p /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg
| + for file in /espressobin/build/tmp/deploy/images/espressobin-v7/$entry
| + '[' 0 -eq 1 ']'
| + destfile=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg/Image
| + '[' -e /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg/Image ']'
| + cp -l /espressobin/build/tmp/deploy/images/espressobin-v7/Image /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg/Image
| + for entry in $image_boot_files
| + echo 'armada-3720-espressobin-v7-emmc.dtb;fdt.dtb'
| + grep -q ';'
| ++ echo 'armada-3720-espressobin-v7-emmc.dtb;fdt.dtb'
| ++ sed -e 's/[^;]*;//'
| + dest=fdt.dtb
| ++ echo 'armada-3720-espressobin-v7-emmc.dtb;fdt.dtb'
| ++ sed -e 's/;.*//'
| + entry=armada-3720-espressobin-v7-emmc.dtb
| + echo fdt.dtb
| + grep -q '/$'
| + dest_is_dir=0
| ++ dirname /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg/fdt.dtb
| + mkdir -p /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg
| + for file in /espressobin/build/tmp/deploy/images/espressobin-v7/$entry
| + '[' 0 -eq 1 ']'
| + destfile=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg/fdt.dtb
| + '[' -e /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg/fdt.dtb ']'
| + cp -l /espressobin/build/tmp/deploy/images/espressobin-v7/armada-3720-espressobin-v7-emmc.dtb /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg/fdt.dtb
| + cat
| + cat
| + '[' 0 -ne 0 ']'
| + cat
| + cat
| + cat
| + echo '### Contents of wks file ###'
| ### Contents of wks file ###
| + cat /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/mender-sdimg.wks
| # embed bootloader
| part --source rawcopy --sourceparams="file=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/u-boot-espressobin-v7.bin" --ondisk "mmcblk0" --align 1 --no-table
| part --source rawcopy --sourceparams="file=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/uboot.env" --ondisk "mmcblk0" --align 8192 --no-table
| part --source rootfs --rootfs-dir /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/bootfs.image_sdimg --ondisk "mmcblk0" --fstype=vfat --label boot --align 8192 --fixed-size 16 --active
| part --source rawcopy --sourceparams="file=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/deploy-core-image-minimal-image-complete/core-image-minimal-espressobin-v7.ext4" --ondisk "mmcblk0" --align 8192 --fixed-size 434176k
| part --ondisk "mmcblk0" --fstype=ext4 --align 8192 --fixed-size 434176k
| part --source rawcopy --sourceparams="file=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/deploy-core-image-minimal-image-complete/core-image-minimal-espressobin-v7.dataimg" --ondisk "mmcblk0" --align 8192 --fixed-size 128
|
| bootloader --ptable msdos
| + echo '### End of contents of wks file ###'
| ### End of contents of wks file ###
| + outimgname=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/deploy-core-image-minimal-image-complete/core-image-minimal-espressobin-v7-20220210145754.sdimg
| + wicout=/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/deploy-core-image-minimal-image-complete/core-image-minimal-espressobin-v7-20220210145754-sdimg
| + BUILDDIR=/espressobin/build
| + wic create /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/mender-sdimg.wks --vars /espressobin/build/tmp/sysroots/espressobin-v7/imgdata/ -e core-image-minimal -o /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/deploy-core-image-minimal-image-complete/core-image-minimal-espressobin-v7-20220210145754-sdimg/
| INFO: Creating image(s)...
|
| ERROR: Actual rootfs size (17958 kB) is larger than allowed size 16384 kB
|
| + bb_exit_handler
| + ret=1
| + case $ret in
| + case $BASH_VERSION in
| + echo 'WARNING: /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/temp/run.do_image_sdimg.101:1 exit 1 from '\''BUILDDIR="/espressobin/build" wic create "$wks" --vars "/espressobin/build/tmp/sysroots/espressobin-v7/imgdata/" -e "core-image-minimal" -o "$wicout/"'\'''
| WARNING: /espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/temp/run.do_image_sdimg.101:1 exit 1 from 'BUILDDIR="/espressobin/build" wic create "$wks" --vars "/espressobin/build/tmp/sysroots/espressobin-v7/imgdata/" -e "core-image-minimal" -o "$wicout/"'
| + exit 1
| ERROR: Execution of '/espressobin/build/tmp/work/espressobin_v7-poky-linux/core-image-minimal/1.0-r0/temp/run.do_image_sdimg.101' failed with exit code 1
ERROR: Task (/espressobin/sources/poky/meta/recipes-core/images/core-image-minimal.bb:do_image_sdimg) failed with exit code '1'
NOTE: Tasks Summary: Attempted 3426 tasks of which 3425 didn't need to be rerun and 1 failed.

Summary: 1 task failed:
  /espressobin/sources/poky/meta/recipes-core/images/core-image-minimal.bb:do_image_sdimg
Summary: There was 1 ERROR message shown, returning a non-zero exit code.
~~~
This error can be fixed by increasing the boot size partition using the configuration variable `MENDER_BOOT_PART_SIZE_MB`, found in `meta-mender/meta-mender-core/classes/mender-setup.bbclass`.